### PR TITLE
DS13 Custom Crates - Original pass

### DIFF
--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -517,6 +517,18 @@
 					/obj/item/clothing/gloves/combat)
 	crate_name = "swat crate"
 
+/datum/supply_pack/security/armory/ERTComm
+	name = "ERT Commander Crate"
+	desc = "!@#$%@#TRANSMISSION START: I have no idea how legal this is, but I'll sell you guys my old outfit, I'm sure CentCom won't care enough to intercept it TRANSMISSION END!!@%$^#"
+	cost = 1000000
+	contains = list(/obj/item/clothing/suit/space/hardsuit/ert,
+					/obj/item/storage/backpack/ert,
+					/obj/item/clothing/shoes/combat/swat,
+					/obj/item/clothing/glasses/hud/security/sunglasses,
+					/obj/item/storage/belt/military/assault,
+					/obj/item/switchblade,
+					/obj/item/clothing/gloves/combat)
+	crate_name = "ERTCommCrate"
 
 /datum/supply_pack/security/armory/wt550
 	name = "WT-550 Auto Rifle Crate"
@@ -553,6 +565,14 @@
 					/obj/machinery/shieldgen)
 	crate_name = "anti-breach shield projector crate"
 
+/datum/supply_pack/engineering/ShowerCrate
+	name = "DIFY Shower Kit"
+	desc = "With the all new, Did it for you(TM) Shower kit, you get one completely assembled shower to be deployed anywhere on station, with a rubber ducky for free! (ONLY OPEN IN FINAL DESIRED LOCATION, NT IS NOT RESPONSIBLE FOR ACCIDENTAL OR EARLY OPENED CRATES)"
+	cost = 2500
+	contains = list(/obj/machinery/shower,
+					/obj/item/bikehorn/rubberducky)
+	crate_name = "ShowerCrate"
+	
 /datum/supply_pack/engineering/conveyor
 	name = "Conveyor Assembly Crate"
 	desc = "Keep production moving along with six conveyor belts. Conveyor switch included. If you have any questions, check out the enclosed instruction book."
@@ -1617,6 +1637,22 @@
 	crate_name = "exotic seeds crate"
 	crate_type = /obj/structure/closet/crate/hydroponics
 
+/datum/supply_pack/organic/strangeseeds
+	name = "Strange Seeds Crate"
+	desc = "Are you tired of trying to sort through seeds? With the all new Strange Seeds Crate(TM) You get all of what you want with none of what you don't!"
+	cost = 10000
+	contains = list(/obj/item/seeds/random,
+					/obj/item/seeds/random,
+					/obj/item/seeds/random,
+					/obj/item/seeds/random,
+					/obj/item/seeds/random,
+					/obj/item/seeds/random,
+					/obj/item/seeds/random,
+					/obj/item/seeds/random,
+					/obj/item/seeds/random,
+					/obj/item/seeds/random)
+	crate_name = "strange seeds crate"
+	crate_type = /obj/structure/closet/crate/hydroponics
 //////////////////////////////////////////////////////////////////////////////
 ////////////////////////////// Livestock /////////////////////////////////////
 //////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Adds some custom crates, specifically, the ERT, Shower, and Strange seeds crates

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR is mainly an exercise in coding for BYOND, but addresses some convenience for DS13, mainly in adding a crate that makes mass ordering seeds easier

# Why It's Good For The Game

Adds some new crates, the strange seeds crate making it easier (but more expensive) to get a large quantity of strange seeds, the shower crate, attempting to bandaid the inability to create showers, and, the ERT Commander crate, creating something other than the bicycle to work towards with cargo points

## Changelog
:cl:
add: Adds Strange seeds crate, contains 10 strange seeds, costs 10,000
add:Adds ERT Commander crate for 1,000,000 credits, contains basic ERT Commander gear, including the hardsuit
add:Adds Shower crate, places a shower where opened, inability to make showers
/:cl: